### PR TITLE
add queueing to delete method so that its not blocking for test kitchen

### DIFF
--- a/bin/poolsclosed
+++ b/bin/poolsclosed
@@ -22,14 +22,14 @@ set :environment, cnf['environment']
 
 get '/machine' do
   response = {}
-  response[:machineRelease] = machines.yield
+  response[:machineRelease] = machines.yield!
   response.to_json
 end
 
 delete '/machine' do
   params['machineName']
   response = {}
-  response[:machineDelete] = machines.delete(params['machineName'])
+  response[:machineDelete] = machines.queue_delete!(params['machineName'])
   response.to_json
 end
 

--- a/spec/poolsclosed/machines_spec.rb
+++ b/spec/poolsclosed/machines_spec.rb
@@ -20,10 +20,10 @@ describe PoolsClosed::Machines do
     end
   end
 
-  context 'add' do
+  context 'add!' do
     it 'adds a machine to redis on success' do
       allow_any_instance_of(PoolsClosed::Jobs).to receive(:create_machine).and_return('succeeded')
-      machines.add
+      machines.add!
       result = @redis_instance.spop('poolsclosed_availmachines')
       expect(result).to include('pool')
     end
@@ -31,7 +31,7 @@ describe PoolsClosed::Machines do
     it 'adds a quarantine to redis on not success' do
       allow_any_instance_of(PoolsClosed::Jobs).to receive(:create_machine).and_return('failure')
 
-      machines.add
+      machines.add!
 
       quarantine_result = @redis_instance.spop('poolsclosed_quarantines')
       expect(quarantine_result).to include('pool')
@@ -41,39 +41,87 @@ describe PoolsClosed::Machines do
     end
   end
 
-  context 'delete' do
+  context 'queue_delete!' do
+    it 'removes an entry from RLSD' do
+      @redis_instance.sadd('poolsclosed_releasedmachines', 'mybox1010')
+
+      machines.queue_delete!('mybox1010')
+
+      rlsd_result = @redis_instance.spop('poolsclosed_releasedmachines')
+      dltd_result = @redis_instance.spop('poolsclosed_deletepending')
+
+      expect(dltd_result).to eq('mybox1010')
+      expect(rlsd_result).to be_nil
+    end
+
+    it 'adds an entry to PDLT' do
+    end
+  end
+
+  context 'delete!' do
     it 'adds a quarantine on failure' do
+      # set up RLDS key
+      @redis_instance.sadd('poolsclosed_releasedmachines', 'pool1234')
+      @redis_instance.spop('poolsclosed_quarantines')
       allow_any_instance_of(PoolsClosed::Jobs).to receive(:delete_machine).and_return('failure')
-      machines.delete('pool1234')
+      machines.delete_helper('pool1234')
       quarantine_result = @redis_instance.spop('poolsclosed_quarantines')
       expect(quarantine_result).to include('pool')
     end
 
-    it "doesn't add a quarantine on success" do
+    it 'does not add an entry to DLTD on failure' do
+      allow_any_instance_of(PoolsClosed::Jobs).to receive(:delete_machine).and_return('failure')
+      machines.delete_helper('pool1234')
+      deleted_result = @redis_instance.spop('poolsclosed_deleted')
+      expect(deleted_result).to be_nil
+    end
+
+    it 'adds an entry to DLTD on success' do
       allow_any_instance_of(PoolsClosed::Jobs).to receive(:delete_machine).and_return('succeeded')
-      machines.delete('pool1235')
+      machines.delete_helper('pool12300')
+      deleted_result = @redis_instance.spop('poolsclosed_deleted')
+      expect(deleted_result).to include('pool')
+    end
+
+    it 'does not add a quarantine on success' do
+      allow_any_instance_of(PoolsClosed::Jobs).to receive(:delete_machine).and_return('succeeded')
+      machines.delete_helper('pool1235')
       quarantine_result = @redis_instance.spop('poolsclosed_quarantines')
       expect(quarantine_result).to be_nil
     end
+
+    it 'removes an entry from PDLT on success' do
+      allow_any_instance_of(PoolsClosed::Jobs).to receive(:delete_machine).and_return('succeeded')
+      machines.delete_helper('pool12301')
+      pendingdelete_result = @redis_instance.spop('poolsclosed_deletepending')
+      expect(pendingdelete_result).to be_nil
+    end
+
+    it 'removes an entry from PDLT on failure' do
+      allow_any_instance_of(PoolsClosed::Jobs).to receive(:delete_machine).and_return('failure')
+      machines.delete_helper('pool12301')
+      pendingdelete_result = @redis_instance.spop('poolsclosed_deletepending')
+      expect(pendingdelete_result).to be_nil
+    end
   end
 
-  context 'yield' do
+  context 'yield!' do
     it 'returns a value that exists in redis' do
       @redis_instance.sadd('poolsclosed_availmachines', 'pool1236')
-      result = machines.yield
+      result = machines.yield!
       expect(result).to eq('pool1236')
     end
 
     it 'adds a yielded machine to released' do
       @redis_instance.sadd('poolsclosed_availmachines', 'pool1237')
-      machines.yield
+      machines.yield!
       result = @redis_instance.spop('poolsclosed_releasedmachines')
       expect(result).to eq('pool1237')
     end
 
     it 'removes a yielded machine from avail' do
       @redis_instance.sadd('poolsclosed_availmachines', 'pool1238')
-      machines.yield
+      machines.yield!
       @redis_instance.spop('poolsclosed_releasedmachines')
       result = @redis_instance.spop('poolsclosed_availmachines')
 
@@ -90,6 +138,15 @@ describe PoolsClosed::Machines do
     end
   end
 
+  context 'pending_deletions' do
+    it 'returns the correct count from redis' do
+      @redis_instance.sadd('poolsclosed_deletepending', 'pool1250')
+      @redis_instance.sadd('poolsclosed_deletepending', 'pool1251')
+      expect(machines.pending_deletions).to eq(2)
+      @redis_instance.del('poolsclosed_deletepending')
+    end
+  end
+
   context 'last_error' do
     it 'returns the last error from redis' do
       @redis_instance.set('poolsclosed_lasterror', 'YIKES!')
@@ -98,9 +155,9 @@ describe PoolsClosed::Machines do
     end
   end
 
-  context 'error' do
+  context 'error!' do
     it 'adds an error to redis' do
-      machines.error('BARF!!')
+      machines.error!('BARF!!')
       result = @redis_instance.get('poolsclosed_lasterror')
       expect(result).to eq('BARF!!')
       @redis_instance.del('poolsclosed_lasterror')

--- a/spec/poolsclosed/poller_spec.rb
+++ b/spec/poolsclosed/poller_spec.rb
@@ -5,14 +5,17 @@ describe 'Poller' do
   before(:each) do
     @machines = PoolsClosed::Machines.new(@cnf)
     @poller = PoolsClosed::Poller.new(@cnf, @machines)
-    allow_any_instance_of(PoolsClosed::Machines).to receive(:add)
-    allow_any_instance_of(PoolsClosed::Machines).to receive(:error)
+    allow(@machines).to receive(:add!)
+    allow(@machines).to receive(:error!)
+    allow(@machines).to receive(:delete!)
+    allow(@machines).to receive(:delete!)
   end
 
   context 'initialize' do
     it 'starts a new thread to poll' do
-      allow_any_instance_of(PoolsClosed::Machines).to receive(:quarantine_count).and_return(0)
-      allow_any_instance_of(PoolsClosed::Machines).to receive(:pool_count).and_return(0)
+      allow(@machines).to receive(:quarantine_count).and_return(0)
+      allow(@machines).to receive(:pool_count).and_return(0)
+      allow(@machines).to receive(:pending_deletions).and_return(0)
       expect(@poller.thread).to_not be_nil
     end
   end
@@ -20,27 +23,59 @@ describe 'Poller' do
   # in our test config the pool size is 10 and the quarantine limit 2
   context 'pool_check' do
     it 'adds a machine when quarantines <= limit and pool_count < limit ' do
-      allow_any_instance_of(PoolsClosed::Machines).to receive(:quarantine_count).and_return(0)
-      allow_any_instance_of(PoolsClosed::Machines).to receive(:pool_count).and_return(5)
+      allow(@machines).to receive(:quarantine_count).and_return(0)
+      allow(@machines).to receive(:pool_count).and_return(5)
+      allow(@machines).to receive(:pending_deletions).and_return(0)
 
       @poller.pool_check
 
-      expect(@machines).to have_received(:add)
+      expect(@machines).to have_received(:add!)
     end
 
-    it 'adds an error when quarantines > limit' do
-      allow_any_instance_of(PoolsClosed::Machines).to receive(:quarantine_count).and_return(1000)
-      allow_any_instance_of(PoolsClosed::Machines).to receive(:pool_count).and_return(0)
+    it 'adds an error when quarantines > limit ' do
+      # TODO: fix this test to handle the deletion case
+      allow(@machines).to receive(:quarantine_count).and_return(1000)
+      allow(@machines).to receive(:pool_count).and_return(0)
+      allow(@machines).to receive(:pending_deletions).and_return(0)
       @poller.pool_check
 
-      expect(@machines).to have_received(:error)
+      expect(@machines).to have_received(:error!)
+    end
+
+    it 'does not add a machine when pending deletions > limit' do
+      allow(@machines).to receive(:pending_deletions).and_return(1000)
+      allow(@machines).to receive(:pool_count).and_return(0)
+      allow(@machines).to receive(:quarantine_count).and_return(0)
+      @poller.pool_check
+
+      expect(@machines).to_not have_received(:add!)
     end
 
     it 'does not add a machine when pool count >= limit' do
-      allow_any_instance_of(PoolsClosed::Machines).to receive(:quarantine_count).and_return(0)
-      allow_any_instance_of(PoolsClosed::Machines).to receive(:pool_count).and_return(0)
+      allow(@machines).to receive(:quarantine_count).and_return(0)
+      allow(@machines).to receive(:pool_count).and_return(1000)
+      allow(@machines).to receive(:pending_deletions).and_return(0)
 
       @poller.pool_check
+      expect(@machines).to_not have_received(:add!)
+    end
+
+    it 'calls delete if there are pending deletions and we are below the quarantine limit' do
+      allow(@machines).to receive(:quarantine_count).and_return(0)
+      allow(@machines).to receive(:pool_count).and_return(0)
+      allow(@machines).to receive(:pending_deletions).and_return(5)
+
+      @poller.pool_check
+      expect(@machines).to have_received(:delete!)
+    end
+
+    it 'does not call delete if there are pending deletions and the quaratine count is too high' do
+      allow(@machines).to receive(:quarantine_count).and_return(10_000)
+      allow(@machines).to receive(:pool_count).and_return(0)
+      allow(@machines).to receive(:pending_deletions).and_return(5)
+
+      @poller.pool_check
+      expect(@machines).to_not have_received(:delete!)
     end
   end
 end


### PR DESCRIPTION
I cleaned up some of the tests as well. Switched from allow_any_instance_of(classname) to just allow(instance). less verbose and its less likely to have false positives
